### PR TITLE
feat: display dynamic active mode and fix system stats in tmux status bar

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Force shell scripts and bin files to always use LF (Unix) line endings
+*.sh text eol=lf
+bin/* text eol=lf

--- a/bin/vanta-mode
+++ b/bin/vanta-mode
@@ -118,9 +118,12 @@ main() {
         work)   setup_work ;;
         chill)  setup_chill ;;
         monitor) setup_monitor ;;
-        help|--help|-h) show_help ;;
-        *)      echo "Unknown mode: $mode" && show_help ;;
+        help|--help|-h) show_help; exit 0 ;;
+        *)      echo "Unknown mode: $mode" && show_help; exit 1 ;;
     esac
+
+    tmux set-option -t "$SESSION" @vanta_mode "$mode"
+    tmux refresh-client -S
 }
 
 main "$@"

--- a/bin/vanta-select
+++ b/bin/vanta-select
@@ -61,6 +61,7 @@ tmux kill-session -t vanta 2>/dev/null
 
 # Start new session (detached)
 tmux -f "$TMUX_CONF" new-session -d -s vanta
+tmux set-option -t vanta @vanta_mode "$mode"
 
 # Add windows based on mode
 case "$mode" in

--- a/bin/vanta.sh
+++ b/bin/vanta.sh
@@ -79,6 +79,7 @@ start_monitor() {
     # Create a fresh session with just the monitor
     tmux -f "$TMUX_CONF" new-session -d -s vanta -n monitor \
         "$VANTA_DIR/modules/monitor.sh $web_flag"
+    tmux set-option -t vanta @vanta_mode "monitor"
 
     # Web display: add a pane showing the URL
     if [ "$web_flag" = "both" ] || [ "$web_flag" = "web" ]; then

--- a/config/vanta.tmux.conf
+++ b/config/vanta.tmux.conf
@@ -57,7 +57,7 @@ set -g @vanta_mode "focus"
 set -g status-interval 2
 set -g status-left-length 50
 set -g status-left "#[fg=#7aa2f7]#[bg=#1a1b26] ⌘ Vanta #[fg=#a9b1d6]• #[fg=#e0af68]#{@vanta_mode} "
-set -g status-right "#[fg=#9ece6a]#(top -bn1 | grep 'Cpu(s)' | awk '{print \"CPU: \" \\$2 \"%\"}') #[fg=#7dcfff]#(free -h | awk '/^Mem/{print \"RAM: \" \\$3 \"/\" \\$2}') #[fg=#bb9af7]#(df -h / | awk 'NR==2{print \"DISK: \" \\$3 \"/\" \\$2}') "
+set -g status-right '#[fg=#9ece6a]#(top -bn1 | grep "Cpu(s)" | awk '\''{print "CPU: " $2 "%"}'\'') #[fg=#7dcfff]#(free -h | awk '\''/^Mem/{print "RAM: " $3 "/" $2}'\'') #[fg=#bb9af7]#(df -h / | awk '\''NR==2{print "DISK: " $3 "/" $2}'\'') '
 set -g status-right-length 100
 
 # === Layout ===

--- a/config/vanta.tmux.conf
+++ b/config/vanta.tmux.conf
@@ -53,8 +53,9 @@ set -g message-style fg=colour223,bg=colour239
 set -g message-command-style fg=colour223,bg=colour239
 
 # === Live Status Bar (CPU/RAM/Disk) ===
+set -g @vanta_mode "focus"
 set -g status-interval 2
-set -g status-left "#[fg=#7aa2f7]#[bg=#1a1b26] ⌘ Vanta "
+set -g status-left "#[fg=#7aa2f7]#[bg=#1a1b26] ⌘ Vanta #[fg=#a9b1d6]• #[fg=#e0af68]#{@vanta_mode} "
 set -g status-right "#[fg=#9ece6a]#(echo 'CPU:' $(top -bn1 | grep "Cpu(s)" | awk '{print $2}')) #[fg=#7dcfff]#(echo 'RAM:' $(free -h | awk '/^Mem/{print $3 "/" $2}')) #[fg=#bb9af7]#(echo 'DISK:' $(df -h / | awk 'NR==2{print $3 "/" $2}')) "
 set -g status-right-length 100
 

--- a/config/vanta.tmux.conf
+++ b/config/vanta.tmux.conf
@@ -57,7 +57,7 @@ set -g @vanta_mode "focus"
 set -g status-interval 2
 set -g status-left-length 50
 set -g status-left "#[fg=#7aa2f7]#[bg=#1a1b26] ⌘ Vanta #[fg=#a9b1d6]• #[fg=#e0af68]#{@vanta_mode} "
-set -g status-right "#[fg=#9ece6a]#(top -bn1 | grep 'Cpu(s)' | awk '{print \"CPU: \" $$2 \"%\"}') #[fg=#7dcfff]#(free -h | awk '/^Mem/{print \"RAM: \" $$3 \"/\" $$2}') #[fg=#bb9af7]#(df -h / | awk 'NR==2{print \"DISK: \" $$3 \"/\" $$2}') "
+set -g status-right "#[fg=#9ece6a]#(top -bn1 | grep 'Cpu(s)' | awk '{print \"CPU: \" \\$2 \"%\"}') #[fg=#7dcfff]#(free -h | awk '/^Mem/{print \"RAM: \" \\$3 \"/\" \\$2}') #[fg=#bb9af7]#(df -h / | awk 'NR==2{print \"DISK: \" \\$3 \"/\" \\$2}') "
 set -g status-right-length 100
 
 # === Layout ===

--- a/config/vanta.tmux.conf
+++ b/config/vanta.tmux.conf
@@ -57,7 +57,7 @@ set -g @vanta_mode "focus"
 set -g status-interval 2
 set -g status-left-length 50
 set -g status-left "#[fg=#7aa2f7]#[bg=#1a1b26] ⌘ Vanta #[fg=#a9b1d6]• #[fg=#e0af68]#{@vanta_mode} "
-set -g status-right "#[fg=#9ece6a]#(echo 'CPU:' $(top -bn1 | grep "Cpu(s)" | awk '{print $2}')) #[fg=#7dcfff]#(echo 'RAM:' $(free -h | awk '/^Mem/{print $3 "/" $2}')) #[fg=#bb9af7]#(echo 'DISK:' $(df -h / | awk 'NR==2{print $3 "/" $2}')) "
+set -g status-right "#[fg=#9ece6a]#(top -bn1 | grep 'Cpu(s)' | awk '{print \"CPU: \" $$2 \"%\"}') #[fg=#7dcfff]#(free -h | awk '/^Mem/{print \"RAM: \" $$3 \"/\" $$2}') #[fg=#bb9af7]#(df -h / | awk 'NR==2{print \"DISK: \" $$3 \"/\" $$2}') "
 set -g status-right-length 100
 
 # === Layout ===

--- a/config/vanta.tmux.conf
+++ b/config/vanta.tmux.conf
@@ -55,6 +55,7 @@ set -g message-command-style fg=colour223,bg=colour239
 # === Live Status Bar (CPU/RAM/Disk) ===
 set -g @vanta_mode "focus"
 set -g status-interval 2
+set -g status-left-length 50
 set -g status-left "#[fg=#7aa2f7]#[bg=#1a1b26] ⌘ Vanta #[fg=#a9b1d6]• #[fg=#e0af68]#{@vanta_mode} "
 set -g status-right "#[fg=#9ece6a]#(echo 'CPU:' $(top -bn1 | grep "Cpu(s)" | awk '{print $2}')) #[fg=#7dcfff]#(echo 'RAM:' $(free -h | awk '/^Mem/{print $3 "/" $2}')) #[fg=#bb9af7]#(echo 'DISK:' $(df -h / | awk 'NR==2{print $3 "/" $2}')) "
 set -g status-right-length 100


### PR DESCRIPTION
### Description
Implements real-time tracking of the active layout mode (`focus`/`work`/`chill`/`all`/`monitor`) in the tmux status bar, fixes status bar truncation issues, and corrects shell expansion bugs on system resource stats (CPU, RAM, DISK).

### Changes
- **Dynamic Mode Status**: Added a session-scoped user option `@vanta_mode` and updated scripts (`vanta.sh`, `vanta-select`, `vanta-mode`) to set it. Mode switches trigger `tmux refresh-client -S` for an instant, zero-latency visual update.
- **Status Left Length**: Increased `status-left-length` from `10` to `50` in `vanta.tmux.conf` to prevent the custom header and mode name from being truncated.
- **System Stats Fix**: Corrected nested double quotes and double-escaped awk variables (`\\$2`, `\\$3`) using outer single quotes in the `status-right` configuration. This prevents runtime shell expansion from breaking the live stats display.
- **Line Endings & Quality**: Standardized all scripts to Unix LF line endings and added `.gitattributes` to enforce it.

Screenshot: 
<img width="1280" height="62" alt="Screenshot 2026-07-01 231422" src="https://github.com/user-attachments/assets/ece998af-9d50-4df3-a72e-0e3c318d2a09" />


Closes #6
